### PR TITLE
Auto build doxygen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
   apt:
     packages:
       - doxygen
+      - graphviz
 
 script:
   - doxygen Doxyfile
@@ -15,7 +16,6 @@ script:
 deploy:
   provider: pages
   skip_cleanup: true
-  local_dir: docs/html
   github_token: $GH_REPO_TOKEN
   on:
-    branch: gh-pages
+    branch: auto_build_doxygen

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
 deploy:
   provider: pages
   skip_cleanup: true
-  local_dir: docs/html
+  local_dir: html
   github_token: $GH_REPO_TOKEN
   on:
     branch: auto_build_doxygen

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: false
+
+branches:
+  only:
+    - auto_build_doxygen
+
+addons:
+  apt:
+    packages:
+      - doxygen
+
+script:
+  - doxygen Doxyfile
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  local_dir: docs/html
+  github_token: $GH_REPO_TOKEN
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ script:
 deploy:
   provider: pages
   skip_cleanup: true
+  local_dir: docs/html
   github_token: $GH_REPO_TOKEN
   on:
     branch: auto_build_doxygen

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ deploy:
   local_dir: docs/html
   github_token: $GH_REPO_TOKEN
   on:
-    branch: master
+    branch: gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 
 branches:
   only:
-    - auto_build_doxygen
+    - master
 
 addons:
   apt:
@@ -19,4 +19,4 @@ deploy:
   local_dir: html
   github_token: $GH_REPO_TOKEN
   on:
-    branch: auto_build_doxygen
+    branch: master

--- a/Doxyfile
+++ b/Doxyfile
@@ -705,7 +705,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error (stderr) by doxygen. If WARNINGS is set to YES

--- a/Doxyfile
+++ b/Doxyfile
@@ -721,7 +721,7 @@ WARNINGS               = YES
 # will automatically be disabled.
 # The default value is: YES.
 
-WARN_IF_UNDOCUMENTED   = YES
+WARN_IF_UNDOCUMENTED   = NO
 
 # If the WARN_IF_DOC_ERROR tag is set to YES, doxygen will generate warnings for
 # potential errors in the documentation, such as not documenting some parameters

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-# Spresense SDK repository
+# Spresense SDK documentation
 
+Latest official release can be found at https://developer.sony.com/develop/spresense/
+
+For the latest beading edge API reference documentation can be found at https://sonydevworld.github.io/spresense/
+
+# Spresense SDK repository
 Clone this repository and update submodules.
 
 ```


### PR DESCRIPTION
Since you've disabled issues, I'm not sure how to contact you about this, but I think it is very relevant for you to know and at least make a note of it in the README for others to see.

Inside sdk/tools/windows/ the flash_writer.exe file gets flagged by Symantec as both a Trojan and a Heuristic virus. I'm guessing this is due to the nature of what flash_writer does, but it would be nice for you to at least make a note of it on your README, if not submit a false positive to Symantec. Hopefully this pull request is not as annoying as what I had to deal with today...