### PR TITLE
SPI connection selectable for TFT display

### DIFF
--- a/sdk/bsp/board/spresense/Kconfig
+++ b/sdk/bsp/board/spresense/Kconfig
@@ -58,12 +58,14 @@ choice
 config LCD_ON_EXTENSION_BOARD
 	bool "Extension board: SPI4"
 	select CXD56_SPI4
+	select CXD56_DMAC_SPI4_TX
 	---help---
 		Display connected to extension board.
 
 config LCD_ON_MAIN_BOARD
 	bool "Main board: SPI5"
 	select CXD56_SPI5
+	select CXD56_DMAC_SPI5_TX
 	---help---
 		Display connected to main board.
 

--- a/sdk/bsp/board/spresense/Kconfig
+++ b/sdk/bsp/board/spresense/Kconfig
@@ -49,4 +49,26 @@ endchoice # "TXS02612 port"
 
 endif # SDCARD_TXS02612
 
+if LCD
+
+choice
+	prompt "LCD SPI connection"
+	default LCD_ON_EXTENSION_BOARD
+
+config LCD_ON_EXTENSION_BOARD
+	bool "Extension board: SPI4"
+	select CXD56_SPI4
+	---help---
+		Display connected to extension board.
+
+config LCD_ON_MAIN_BOARD
+	bool "Main board: SPI5"
+	select CXD56_SPI5
+	---help---
+		Display connected to main board.
+
+endchoice
+
+endif
+
 endif

--- a/sdk/bsp/board/spresense/include/board.h
+++ b/sdk/bsp/board/spresense/include/board.h
@@ -186,10 +186,21 @@ enum board_power_device {
 
 /* Display device pin definitions ******************************************/
 
+#if defined(CONFIG_LCD_ON_MAIN_BOARD) /* Display connected to main board. */
+
+#define DISPLAY_RST     PIN_I2S0_BCK
+#define DISPLAY_DC      PIN_I2S0_LRCK
+
+#define DISPLAY_SPI     5
+
+#else /* Display is connected through extension board. */
+
 #define DISPLAY_RST     PIN_SPI2_MISO
 #define DISPLAY_DC      PIN_PWM2
 
 #define DISPLAY_SPI     4
+
+#endif
 
 /* Imager device pin definitions *******************************************/
 


### PR DESCRIPTION
* This makes it possible to select what board the
  TFT display is connected to. Main board or extensionboard.