### PR TITLE
Fixed flash.sh to work on macOS

### DIFF
--- a/sdk/tools/flash.sh
+++ b/sdk/tools/flash.sh
@@ -35,7 +35,7 @@
 ############################################################################
 
 CURRENT_DIR=`pwd`
-SCRIPT_NAME=`readlink -e "${BASH_SOURCE[0]}"`
+SCRIPT_NAME=$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)/$(basename "${BASH_SOURCE[0]}")
 SCRIPT_DIR=`dirname "$SCRIPT_NAME"`
 
 # function   : show_help

--- a/sdk/tools/flash.sh
+++ b/sdk/tools/flash.sh
@@ -116,7 +116,7 @@ case "$(uname -s)" in
 		PLATFORM=linux
 		;;
 	Darwin*)
-		PLATFORM=macosx
+		PLATFORM=macos
 		;;
 	CYGWIN*|MINGW32*|MSYS*)
 		PLATFORM=windows


### PR DESCRIPTION
fix the script to work on macOS.

# Not to use `readlink`

```bash
$ ./tools/flash.sh -e /Users/chibiegg/Downloads/spresense-binaries-v1.2.1.zip 
readlink: illegal option -- e
usage: readlink [-n] [file ...]
./tools/flash.sh: line 96: ./eula.py: No such file or directory
```

# Fix platform directory name

```bash
$ ./tools/flash.sh -l ../firmware/spresense -c /dev/tty.SLAB_USBtoUART 
./tools/flash.sh: line 132: ./macosx/flash_writer: No such file or directory
```

# Set executable permission flag

```bash
$ ./tools/flash.sh -l ../firmware/spresense -c /dev/tty.SLAB_USBtoUART 
./tools/flash.sh: line 132: /Users/chibiegg/Develop/spresense/sdk/tools/macos/flash_writer: Permission denied
```