### PR TITLE
Work around GNSS initialization error

### DIFF
--- a/examples/gnss_factory/gnss_factory_main.c
+++ b/examples/gnss_factory/gnss_factory_main.c
@@ -201,8 +201,10 @@ int gnss_factory_test(int argc, char *argv[])
 
   if (ret == OK)
     {
-      /* Call factory test */
+      /* Wait HW initialization done. */
+      sleep(3);
 
+      /* Call factory test */
       ret = gnss_factory_main(argc, argv);
     }
 


### PR DESCRIPTION
GNSS Start is failed when `CONFIG_SDK_USER_ENTRYPOINT=gnss_factory_test` .

```
Hello, FACTORY SAMPLE!!
start error -1
End of FACTORY Sample:-1
```

This PR is the workaround.

Please refer https://ja.stackoverflow.com/q/54647 .
