### PR TITLE
Fix a bug when set SPRESENSE_HOME to empty

### DIFF
--- a/sdk/tools/config.py
+++ b/sdk/tools/config.py
@@ -111,9 +111,10 @@ def get_all_defconfigs(configdir):
 
     if 'SPRESENSE_HOME' in os.environ:
         myapp_root = os.environ['SPRESENSE_HOME']
-        for app_config in glob.glob(os.path.join(myapp_root, '*', 'configs')):
-            appname = os.path.basename(os.path.dirname(app_config))
-            get_defconfigs(app_config, category=CAT_MYAPP, prefix=appname)
+        if os.path.isdir(myapp_root):
+            for app_config in glob.glob(os.path.join(myapp_root, '*', 'configs')):
+                appname = os.path.basename(os.path.dirname(app_config))
+                get_defconfigs(app_config, category=CAT_MYAPP, prefix=appname)
 
 def get_defconfig_src(defconfig, kernel):
     if kernel:

--- a/sdk/tools/gentmpkconfig.py
+++ b/sdk/tools/gentmpkconfig.py
@@ -60,7 +60,9 @@ kconfigs = glob.glob('../*/Kconfig')
 
 # Add kconfigs from user application
 if 'SPRESENSE_HOME' in os.environ:
-    kconfigs = kconfigs + glob.glob(os.path.join(os.environ['SPRESENSE_HOME'], "Kconfig"))
+    myapp_root = os.environ['SPRESENSE_HOME']
+    if os.path.isdir(myapp_root):
+        kconfigs = kconfigs + glob.glob(os.path.join(myapp_root, "Kconfig"))
 
 for c in kconfigs:
     dn = os.path.dirname(c).split('/')[-1]


### PR DESCRIPTION
In SPRESENSE_HOME is set to empty, tools/config.py will be face
error because config.py is checking a Kconfig file in
SPRESENSE_HOME.