### PR TITLE
Building the docker image (with Dockerfile) fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN mkdir -p $HOME/spresenseenv/usr
 RUN bash  ./install-tools.sh
 ENV PATH "$PATH:/$HOME/spresenseenv/usr/bin"
 RUN ldconfig
-RUN rm -v /*.tgz /*tar.bz2 /*.tgz.sha
+RUN rm -fv /*.tgz /*tar.bz2 /*.tgz.sha
 
 # Clean up APT when done.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
## Description of the issue:
Building `Dockerfile` fails with the following results (excerpt of the full output):

```
Setting up git (1:2.17.1-1ubuntu0.8) ...
Setting up build-essential (12.4ubuntu1) ...
Setting up pkg-config (0.29.1-0ubuntu2) ...
Processing triggers for libc-bin (2.27-3ubuntu1) ...
== Install additional tools
=== Download nuttx-tools.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  997k  100  997k    0     0  1113k      0 --:--:-- --:--:-- --:--:-- 1111k[0m[91m
=== tar xvzf nuttx-tools.tar.gz --strip-components=1 -C nuttx-tools  .................
=== ./configure --prefix=//spresenseenv/usr --disable-shared --disable-nconf  ..............
=== make install  ......
== Install cross toolchain
=== Download gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   245  100   245    0     0    478      0 --:--:-- [0m[91m--:--:-- --:--:--   477
100 95.9M  100 95.9M    0     0  14.9M      0  0:00:06  0:00[0m[91m:06 --:--:-- 17.5M
gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2: OK
=== tar vjxf gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2 --strip-components=1 -C //spresenseenv/usr  .......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
=== Download openocd-0.10.0-spr1-20191113-linux64.tar.bz2
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   652  100   652    0     0   2256      0 --:--:-- --:--:-- --:[0m[91m--:--  2256
100 4876k  100 4876k    0     0  5896k      0 --:--:-- --:--:-- --:--:-- 5896k
=== Download openocd-0.10.0-spr1-20191113-linux64.tar.bz2.sha
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   656  100   656    0  [0m[91m   0   250[0m[91m3 [0m[91m     0 -[0m[91m-:--:-- --:--:-- --:--:--  2494
100   111  100   111    0     0    275      0 --:--:-- --:--:-- --:--:--   275
openocd-0.10.0-spr1-20191113-linux64.tar.bz2: OK
=== tar vjxf openocd-0.10.0-spr1-20191113-linux64.tar.bz2 --strip-components=1 -C //spresenseenv/usr  ................................................................................
Installation is done.
Removing intermediate container df2d68dfac90
 ---> c748671f643a
Step 15/18 : ENV PATH "$PATH:/$HOME/spresenseenv/usr/bin"
 ---> Running in e507aee98be2
Removing intermediate container e507aee98be2
 ---> 67a383149265
Step 16/18 : RUN ldconfig
 ---> Running in 889dd5df3cc7
Removing intermediate container 889dd5df3cc7
 ---> 82ae399d6067
Step 17/18 : RUN rm -v /*.tgz /*tar.bz2 /*.tgz.sha
 ---> Running in 7b33cdb288c2
rm: cannot remove '/*.tgz': No such file or directory
rm: cannot remove '/*.tgz.sha': No such file or directory
removed '/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2'
removed '/openocd-0.10.0-spr1-20191113-linux64.tar.bz2'
The command '/bin/sh -c rm -v /*.tgz /*tar.bz2 /*.tgz.sha' returned a non-zero code: 1
```


## How to reproduce:

```
docker build -t spresense-sdk -f Dockerfile .
```

## Describe your hardware setup:

OS: Arch Linux
Kernel: x86_64 Linux 5.11.2-arch1-1

## Software version used

Docker version 20.10.5, build 55c4c88966