### PR TITLE
README's docker example is not super clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ $ source spresense_env.sh
 This script will create an alias `spresense` which should preceed the regular SDK build scripts and Make commands.
 examples
 ```
-SpresenseSDK: $ spresense make
+SpresenseSDK: $ spresense sh -c "cd /spresense/sdk && tools/config.py examples/hello"
+SpresenseSDK: $ spresense sh -c "make"
 ```
 
 # Spresense SDK build instructions

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ $ source spresense_env.sh
 This script will create an alias `spresense` which should preceed the regular SDK build scripts and Make commands.
 examples
 ```
-SpresenseSDK: $ spresense sh -c "cd /spresense/sdk && tools/config.py examples/hello"
-SpresenseSDK: $ spresense sh -c "make"
+SpresenseSDK: $ spresense tools/config.py examples/hello
+SpresenseSDK: $ spresense make
 ```
 
 # Spresense SDK build instructions


### PR DESCRIPTION
The example in the README when using docker is erroneous and incomplete.
It would be better to give a complete example.