### PR TITLE
examples/lte_azureiot: Notify completed file operation 

### DIFF
--- a/examples/lte_azureiot/azureiot_if.h
+++ b/examples/lte_azureiot/azureiot_if.h
@@ -44,6 +44,11 @@
 #define AZURE_IOT_INFO_ID_MAX_SIZE     (64)
 #define AZURE_IOT_INFO_PRIKEY_MAX_SIZE (64)
 
+#define AZURE_IOT_NOTIFY_STATUS_BODY_FORMAT "{\"correlationId\":\"%s\", \
+\"isSuccess\":%s, \
+\"statusCode\":%s, \
+\"statusDescription\":\"\"}"
+
 /****************************************************************************
  * Public types
  ****************************************************************************/
@@ -136,6 +141,22 @@ int azureiot_create_fileinfo_msg(struct azureiot_info *info,
                                  char                 *request,
                                  int                   request_size,
                                  const char           *file_name);
+
+/*!
+ * \brief      Create http command to notify completed file operation
+ * \param[in]  info         : Information for Azure connection
+ * \param[out] request      : Command creation buffer
+ * \param[in]  request_size : Buffer size
+ * \param[in]  is_success   : true = successful, false = failed
+ * \param[in]  status_code  : Status code of operation
+ * \retval <=0 NG
+ */
+
+int azureiot_create_notifymsg(struct azureiot_info *info,
+                              char                 *request,
+                              int                   request_size,
+                              bool                  is_success,
+                              int                   status_code);
 
 /*!
  * \brief      Create http command to upload file to Azure


### PR DESCRIPTION
The device should update the file operation status with IoT Hub regardless of whether the operation succeeds or fails.

https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-file-upload#notify-iot-hub-of-a-completed-file-upload-rest

It will be reached the limit if it upload/download over 10 times in a short time without this patch.

https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-quotas-throttling#other-limits

```
Not SAS URI
```