### PR TITLE
fix memory leak with mqtt disconnect

### DIFF
--- a/examples/lte_awsiot/subscribe_publish_sample.c
+++ b/examples/lte_awsiot/subscribe_publish_sample.c
@@ -275,6 +275,7 @@ int main(int argc, char FAR **argv)
 		IOT_INFO("Publish done\n");
 	}
 
+	aws_iot_mqtt_disconnect(&client);
 	app_awsiot_disconnect_from_lte();
 
 	return rc;


### PR DESCRIPTION
lte_awsiot exampleは実行終了時にaws_iot_mqtt_disconnect()処理が漏れたで、
メモリリークが発生します。lte_awsiot -x 1コマンドで連続20回を実行すると、
メモリはだんだんなくなり、エラーが発生します。