### PR TITLE
examples/lte_azureiot: Use stat() instead of fseek() to get filelength

### DIFF
--- a/examples/lte_azureiot/lte_azureiot_main.c
+++ b/examples/lte_azureiot/lte_azureiot_main.c
@@ -42,6 +42,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <sys/stat.h>
 #include "azureiot_if.h"
 #include "lte_connection.h"
 #include "mbedtls_if.h"
@@ -495,25 +496,19 @@ static int recv_message(struct azureiot_info *info,
 /* ------------------------------------------------------------------------ */
 static int filelength(const char *file_name)
 {
-  int    size = ERROR;
-  FILE  *fp   = fopen(file_name, "rb");
+  struct stat st;
 
-  if (fp)
+  if (stat(file_name, &st))
     {
-      if (fseek(fp, 0L, SEEK_END) == 0)
-        {
-          fpos_t pos;
-
-          if (fgetpos(fp, &pos) == 0)
-            {
-              size = (int)pos;
-            }
-        }
-
-      fclose(fp);
+      return ERROR;
     }
 
-  return (int)size;
+  if ((st.st_mode & S_IFMT) != S_IFREG)
+    {
+      return ERROR;
+    }
+
+  return st.st_size;
 }
 
 /* ------------------------------------------------------------------------ */


### PR DESCRIPTION
Sometimes ```filelength()``` returns invalid length with ```fseek()``` implementations.

In the following case, ``hogehoge.JPG`` is a valid JPEG file.

```
LTE connect...
LTE connect...OK

Upload device: /mnt/sd0/images/hogehoge.JPG --> cloud: hogehoge.JPG
File open error or file size is 0.(-1)
```

It can be avoided with ```stat()``` one.

```
LTE connect...
LTE connect...OK

Upload device: /mnt/sd0/images/hogehoge.JPG --> cloud: hogehoge.JPG
Upload start
720/278528
1744/278528
2768/278528
...
277200/278528
278224/278528
278528/278528
Upload end
Successful
Notify OK
```
