### PR TITLE
lte_azureiot: Add DigiCert Global Root G2

### DIFF
--- a/examples/lte_azureiot/README.md
+++ b/examples/lte_azureiot/README.md
@@ -33,21 +33,6 @@ myDeviceId
 HZAww1PN3suNBkailQU1UeEllNB3j0=
 ```
 
-###### AZURE_IOT_CERT_FILE_NAME
-
-File defined by 'AZURE_IOT_CERT_FILE_NAME' in "lte_azureiot_main.c".
-
-("/mnt/sd0/CERTS/portal-azure-com.pem" by default)
-
-Please download certification file as "portal-azure-com.pem" from Microsoft Azure Portal.
-(This step is just for firefox web browser.)
-
-1. Open the "https://portal.azure.com" in the Firefox
-
-2. Open the certification details (Baltimore CyberTrust Root)
-
-3. Download the certification file (portal-azure-com.pem)
-
 ##### Build kernel and SDK:
 
 This application can be used by lte_azureiot default config.

--- a/examples/lte_azureiot/lte_azureiot_main.c
+++ b/examples/lte_azureiot/lte_azureiot_main.c
@@ -70,18 +70,60 @@
 
 #define AZURE_IOT_RESOURCE_FILE     "/mnt/sd0/azureiot/resources.txt"
 
-/* Specify the file name of the certificate of the Azure portal */
-
-#define AZURE_IOT_CERT_FILE_NAME    "/mnt/sd0/CERTS/portal-azure-com.pem"
-
 /****************************************************************************
  * Private Data
  ****************************************************************************/
 
-/* Certificate file deployment location and buffer size */
+/* Root certificates */
 
-static char s_cert_file[8192];
-static int  s_cert_file_size;
+static char certificates[] =
+/* DigiCert Global Root G2 */
+"-----BEGIN CERTIFICATE-----\r\n"
+"MIIDjjCCAnagAwIBAgIQAzrx5qcRqaC7KGSxHQn65TANBgkqhkiG9w0BAQsFADBh\r\n"
+"MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\r\n"
+"d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBH\r\n"
+"MjAeFw0xMzA4MDExMjAwMDBaFw0zODAxMTUxMjAwMDBaMGExCzAJBgNVBAYTAlVT\r\n"
+"MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j\r\n"
+"b20xIDAeBgNVBAMTF0RpZ2lDZXJ0IEdsb2JhbCBSb290IEcyMIIBIjANBgkqhkiG\r\n"
+"9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuzfNNNx7a8myaJCtSnX/RrohCgiN9RlUyfuI\r\n"
+"2/Ou8jqJkTx65qsGGmvPrC3oXgkkRLpimn7Wo6h+4FR1IAWsULecYxpsMNzaHxmx\r\n"
+"1x7e/dfgy5SDN67sH0NO3Xss0r0upS/kqbitOtSZpLYl6ZtrAGCSYP9PIUkY92eQ\r\n"
+"q2EGnI/yuum06ZIya7XzV+hdG82MHauVBJVJ8zUtluNJbd134/tJS7SsVQepj5Wz\r\n"
+"tCO7TG1F8PapspUwtP1MVYwnSlcUfIKdzXOS0xZKBgyMUNGPHgm+F6HmIcr9g+UQ\r\n"
+"vIOlCsRnKPZzFBQ9RnbDhxSJITRNrw9FDKZJobq7nMWxM4MphQIDAQABo0IwQDAP\r\n"
+"BgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBhjAdBgNVHQ4EFgQUTiJUIBiV\r\n"
+"5uNu5g/6+rkS7QYXjzkwDQYJKoZIhvcNAQELBQADggEBAGBnKJRvDkhj6zHd6mcY\r\n"
+"1Yl9PMWLSn/pvtsrF9+wX3N3KjITOYFnQoQj8kVnNeyIv/iPsGEMNKSuIEyExtv4\r\n"
+"NeF22d+mQrvHRAiGfzZ0JFrabA0UWTW98kndth/Jsw1HKj2ZL7tcu7XUIOGZX1NG\r\n"
+"Fdtom/DzMNU+MeKNhJ7jitralj41E6Vf8PlwUHBHQRFXGU7Aj64GxJUTFy8bJZ91\r\n"
+"8rGOmaFvE7FBcf6IKshPECBV1/MUReXgRPTqh5Uykw7+U0b6LJ3/iyK5S9kJRaTe\r\n"
+"pLiaWN0bfVKfjllDiIGknibVb63dDcY3fe0Dkhvld1927jyNxF1WW6LZZm6zNTfl\r\n"
+"MrY=\r\n"
+"-----END CERTIFICATE-----\r\n"
+
+/* Baltimore CyberTrust Root */
+"-----BEGIN CERTIFICATE-----\r\n"
+"MIIDdzCCAl+gAwIBAgIEAgAAuTANBgkqhkiG9w0BAQUFADBaMQswCQYDVQQGEwJJ\r\n"
+"RTESMBAGA1UEChMJQmFsdGltb3JlMRMwEQYDVQQLEwpDeWJlclRydXN0MSIwIAYD\r\n"
+"VQQDExlCYWx0aW1vcmUgQ3liZXJUcnVzdCBSb290MB4XDTAwMDUxMjE4NDYwMFoX\r\n"
+"DTI1MDUxMjIzNTkwMFowWjELMAkGA1UEBhMCSUUxEjAQBgNVBAoTCUJhbHRpbW9y\r\n"
+"ZTETMBEGA1UECxMKQ3liZXJUcnVzdDEiMCAGA1UEAxMZQmFsdGltb3JlIEN5YmVy\r\n"
+"VHJ1c3QgUm9vdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKMEuyKr\r\n"
+"mD1X6CZymrV51Cni4eiVgLGw41uOKymaZN+hXe2wCQVt2yguzmKiYv60iNoS6zjr\r\n"
+"IZ3AQSsBUnuId9Mcj8e6uYi1agnnc+gRQKfRzMpijS3ljwumUNKoUMMo6vWrJYeK\r\n"
+"mpYcqWe4PwzV9/lSEy/CG9VwcPCPwBLKBsua4dnKM3p31vjsufFoREJIE9LAwqSu\r\n"
+"XmD+tqYF/LTdB1kC1FkYmGP1pWPgkAx9XbIGevOF6uvUA65ehD5f/xXtabz5OTZy\r\n"
+"dc93Uk3zyZAsuT3lySNTPx8kmCFcB5kpvcY67Oduhjprl3RjM71oGDHweI12v/ye\r\n"
+"jl0qhqdNkNwnGjkCAwEAAaNFMEMwHQYDVR0OBBYEFOWdWTCCR1jMrPoIVDaGezq1\r\n"
+"BE3wMBIGA1UdEwEB/wQIMAYBAf8CAQMwDgYDVR0PAQH/BAQDAgEGMA0GCSqGSIb3\r\n"
+"DQEBBQUAA4IBAQCFDF2O5G9RaEIFoN27TyclhAO992T9Ldcw46QQF+vaKSm2eT92\r\n"
+"9hkTI7gQCvlYpNRhcL0EYWoSihfVCr3FvDB81ukMJY2GQE/szKN+OMY3EU/t3Wgx\r\n"
+"jkzSswF07r51XgdIGn9w/xZchMB5hbgF/X++ZRGjD8ACtPhSNzkE1akxehi/oCr0\r\n"
+"Epn3o0WC4zxe9Z2etciefC7IpJ5OCBRLbf1wbWsaY71k5h+3zvDyny67G7fyUIhz\r\n"
+"ksLi4xaNmjICq44Y3ekQEe5+NauQrz4wlHrQMz2nZQ/1/I6eYs9HRCwBXbsdtTLS\r\n"
+"R9I4LtD+gdwyah617jzV/OeBHRnDJELqYzmp\r\n"
+"-----END CERTIFICATE-----\r\n"
+;
 
 /* Azure resources */
 
@@ -355,7 +397,7 @@ static int send_and_recv_message(const char *hostname,
   int headlen = 0;
   int remain  = 0;
 
-  if (tls_connect(hostname, s_cert_file, s_cert_file_size) < 0)
+  if (tls_connect(hostname, certificates, sizeof(certificates)) < 0)
     {
       printf("Fail: Connect\n");
       goto exit_without_disconnect;
@@ -707,7 +749,7 @@ static int upload(struct azureiot_info *info,
       return ERROR;
     }
 
-  if (tls_connect(hostname, s_cert_file, s_cert_file_size) != 0)
+  if (tls_connect(hostname, certificates, sizeof(certificates)) != 0)
     {
       printf("Fail connect!\n");
 
@@ -836,7 +878,7 @@ static int download(struct azureiot_info *info,
 
   /* Open download destination file */
 
-  if (tls_connect(hostname, s_cert_file, s_cert_file_size) != 0)
+  if (tls_connect(hostname, certificates, sizeof(certificates)) != 0)
     {
       printf("Fail: Connect!\n");
 
@@ -989,25 +1031,6 @@ errout:
 }
 
 /* ------------------------------------------------------------------------ */
-static int extract_certificate_file(const char *cert_file)
-{
-  FILE  *fp = fopen(cert_file, "rb");
-
-  if (fp == NULL)
-    {
-      printf("Missing certificate file.\n");
-
-      return ERROR;
-    }
-
-  s_cert_file_size = fread(s_cert_file, 1, sizeof(s_cert_file), fp);
-
-  fclose(fp);
-
-  return OK;
-}
-
-/* ------------------------------------------------------------------------ */
 int  usage(void)
 {
   printf("usage: lte_azureiot <command> [arg1] [arg1]\n\n");
@@ -1082,13 +1105,6 @@ int main(int argc, FAR char *argv[])
   info.IoTHubName = IoTHubName;
   info.DeviceID   = DeviceID;
   info.PrimaryKey = PrimaryKey;
-
-  /* Extracting the certificate file */
-
-  if (extract_certificate_file(AZURE_IOT_CERT_FILE_NAME) < 0)
-    {
-      return ERROR;
-    }
 
   printf("LTE connect...\n");
 


### PR DESCRIPTION
Baltimore CyberTrust Root is expiring in May 2025. Therefore, Azure IoT Hub moves it to DigiCert Global G2 Root until October 2023.

https://learn.microsoft.com/en-us/azure/iot-hub/migrate-tls-certificate

All devices in Azure IoT Hub typically uses the same root CA. So Spresense hasn't to have it as a file.

Ref: https://github.com/Azure/azure-iot-sdk-c/blob/main/certs/certs.c